### PR TITLE
Add list of version of pubmed-to-gse endpoint

### DIFF
--- a/src/app/app.py
+++ b/src/app/app.py
@@ -176,6 +176,78 @@ def get_pubmed_to_gse():
         logger.exception(f'/pubmed-to-gse exception {e}')
         return jsonify({"error": str(e)}), 500
 
+@app.route('/pubmed-to-gse-flat', methods=['POST'])
+def get_pubmed_to_gse_flat():
+    """
+    POST endpoint to retrieve a list of GSE accession numbers for PubMed IDs.
+    ---
+    summary: Get a ist of GSE accession numbers for PubMed IDs
+    description: |
+      Retrieves Gene Expression Omnibus Series (GSE) accession numbers linked to the provided PubMed IDs.
+      The response is a list of unique dataset accessions.
+      Provide JSON array of PubMed IDs in request body.
+    parameters:
+      - name: body
+        in: body
+        required: true
+        description: JSON array of PubMed IDs
+        schema:
+          type: object
+          properties:
+            pubmed_ids:
+              type: array
+              items:
+                type: string
+          example:
+            pubmed_ids: ["30530648", "31018141"]
+    responses:
+      200:
+        description: Successful response with a list of GSE accessions
+        schema:
+          type: array
+          items:
+            type: string
+        examples:
+          application/json:
+            - "GSE116672"
+            - "GSE127884"
+            - "GSE127892"
+            - "GSE127893"
+      400:
+        description: Bad request - missing or invalid PubMed IDs
+        schema:
+          type: object
+          properties:
+            error:
+              type: string
+              example: "pubmed_ids parameter is required"
+        examples:
+          application/json:
+            error: "pubmed_ids parameter is required"
+    """
+    logger.info(f'/pubmed-to-gse-flat {log_request(request)}')
+
+    data = request.get_json()
+    if not data or 'pubmed_ids' not in data:
+        logger.error(f'/pubmed-to-gse-flat error {log_request(request)}')
+        return jsonify({"error": "pubmed_ids parameter is required"}), 400
+    pubmed_ids = data['pubmed_ids']
+    if not isinstance(pubmed_ids, list):
+        return jsonify({"error": "pubmed_ids must be an array"}), 400
+    pubmed_ids = [str(pid).strip() for pid in pubmed_ids if str(pid).strip()]
+
+    if not pubmed_ids:
+        return jsonify({"error": "At least one valid PubMed ID is required"}), 400
+
+    try:
+        with requests.Session() as http_session:
+            linker = create_chained_linker(http_session)
+            gse_ids = linker.link_to_datasets(pubmed_ids)
+            return jsonify([gse_id for gse_id in gse_ids if gse_id.startswith("GSE")])
+
+    except Exception as e:
+        logger.exception(f'/pubmed-to-gse-flat exception {e}')
+        return jsonify({"error": str(e)}), 500
 
 @app.route('/gse-details', methods=['POST'])
 def get_gse_details():


### PR DESCRIPTION
This PR introduces the `/pubmed-to-gse-flat` endpoint, which returns GEO accessions of datasets associated with a list of PubMed IDs as a list rather than a dictionary. The motivation for adding this endpoint is the need to call ELink individually for every input PubMed ID. The new endpoint reduces latency by requiring only 1 ELink call regardless of input size.

The only change in this PR is the addition of the `/pubmed-to-gse-flat` endpoint, since the `DatasetLinker` interface already supports this use case. 