### PR TITLE
Speed up paper-dataset linking

### DIFF
--- a/src/app/app.py
+++ b/src/app/app.py
@@ -502,6 +502,7 @@ def get_relevant_datasets():
         return jsonify({"error": "query must be a non-empty string"}), 400
 
     gse_accessions = [str(gid).strip().upper() for gid in gse_ids if str(gid).strip()]
+    gse_accessions = list(filter(lambda gid: gid.startswith('GSE'), gse_accessions))
     if not gse_accessions:
         return jsonify({"error": "At least one valid GSE ID is required"}), 400
 
@@ -606,6 +607,7 @@ def get_relevant_datasets_by_embedding():
     if not isinstance(gse_accessions, list) or not gse_accessions:
         return jsonify({"error": "gse_accessions must be a non-empty list"}), 400
     gse_accessions = [str(acc).strip() for acc in gse_accessions if str(acc).strip()]
+    gse_accessions = list(filter(lambda gid: gid.startswith('GSE'), gse_accessions))
     if not gse_accessions:
         return jsonify({"error": "At least one valid GSE accession is required"}), 400
 

--- a/src/db/linkers/elink_dataset_linker.py
+++ b/src/db/linkers/elink_dataset_linker.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import xml.etree.ElementTree as ET
 from typing import List, Dict
 
 import requests
@@ -16,6 +17,7 @@ eutilities_rate_limiter = create_inmemory_limiter()
 class ELinkDatasetLinker(PaperDatasetLinker):
     ELINK_REQUEST_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi"
     EFETCH_REQUEST_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+    ESUMMARY_REQUEST_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi"
     NUMBER_OF_RETRIES = 3
 
     def __init__(self, http_session: requests.Session):
@@ -39,20 +41,51 @@ class ELinkDatasetLinker(PaperDatasetLinker):
         """
         if not pubmed_ids:
             raise ValueError("At least one valid PubMed ID is required")
-
-        result: Dict[str, List[str]] = {}
-
-        for pubmed_id in pubmed_ids:
-            try:
-                # Call link_to_datasets for each individual PubMed ID
-                accessions = self.link_to_datasets([pubmed_id])
-                result[pubmed_id] = accessions
-            except Exception:
-                # If a single ID fails, store empty list and continue
-                logging.exception(f"Error linking PubMed ID {pubmed_id}")
-                result[pubmed_id] = []
-
+        geo_ids = self._fetch_geo_ids(pubmed_ids)
+        result: Dict[str, List[str]] = {pmid: [] for pmid in pubmed_ids}
+        if not geo_ids:
+            return result
+        self._fetch_geo_accessions_mapped(geo_ids, result)
         return result
+
+    @tenacity.retry(wait=tenacity.wait_exponential(max=10), stop=tenacity.stop_after_attempt(NUMBER_OF_RETRIES),
+                    before_sleep=tenacity.before_sleep_log(logger, logging.WARNING), reraise=True)
+    @eutilities_rate_limiter.as_decorator(name="e-utilities", weight=1)
+    def _fetch_geo_accessions_mapped(self, geo_ids: List[str], pubmedIdToGSENumber: Dict[str, List[str]]) -> None:
+        """
+        Fetches GEO accessions for the given GEO IDs via eSummary and populates
+        the result mapping from PubMed ID to GSE accession numbers.
+
+        Each eSummary DocSum contains a ``PubMedIds`` list and an ``Accession``
+        field. For every PubMed ID listed in a DocSum, the corresponding GSE
+        accession is appended to ``result[pubmed_id]`` when that PubMed ID is
+        already a key in *result*.
+
+        :param geo_ids: GEO dataset IDs to summarise (``db=gds``).
+        :param pubmedIdToGSENumber: Mutable mapping of PubMed ID → accession list to populate.
+        """
+        try:
+            response = self.http_session.post(
+                ELinkDatasetLinker.ESUMMARY_REQUEST_URL,
+                params={"db": "gds"},
+                data={"id": ",".join(geo_ids)},
+            )
+            response.raise_for_status()
+            root = ET.fromstring(response.text)
+            for doc_sum in root.findall("DocSum"):
+                accession_item = doc_sum.find("Item[@Name='Accession'][@Type='String']")
+                if accession_item is None or not (accession_item.text or "").startswith("GSE"):
+                    continue
+                for int_item in doc_sum.findall("Item[@Name='PubMedIds']/Item"):
+                    pmid = int_item.text
+                    if pmid and pmid in pubmedIdToGSENumber:
+                        pubmedIdToGSENumber[pmid].append(accession_item.text)
+        except ET.ParseError as e:
+            raise EntrezError(f"Failed to parse eSummary XML: {e}")
+        except requests.HTTPError as e:
+            raise EntrezError(f"eSummary status {e.response.status_code}")
+        except requests.RequestException:
+            raise EntrezError("Network error during eSummary API call")
 
     @tenacity.retry(wait=tenacity.wait_exponential(max=10), stop=tenacity.stop_after_attempt(NUMBER_OF_RETRIES),
                     before_sleep=tenacity.before_sleep_log(logger, logging.WARNING), reraise=True)


### PR DESCRIPTION
This PR changes the `ELinkDatasetLinker` to optimize the process of linking papers to GEO datasets. 

Instead of making individual ELink calls per paper, a new method using two batched requests is introduced:
1. Issue a single Elink request for datasets associated with all papers in the input list of PubMed IDs
2. Send a ESummary request for the retrieved dataset IDs, which will yield both their accession numbers and related publications