### PR TITLE
Health check endpoint and correct app port in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The Relevant Datasets feature supports the following properties in `config.prope
 You can start the app using this command:
 
 ```aiignore
-uv run -- flask --app src.app.app run --port 5002
+uv run -- flask --app src.app.app run --port 5003
 ```
 
 The app will be available at `http://localhost:5002`.

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -106,6 +106,22 @@ def _get_gsm_details(gsm_accessions: list[str], http_session) -> list[GSM]:
     )
     return chained_loader.get_gsms(gsm_accessions)
 
+@app.route("/")
+def health_check():
+    """
+    GET endpoint to check if the service is running.
+    ---
+    summary: Health check
+    description: Returns a plain-text message confirming the service is up.
+    responses:
+      200:
+        description: Service is running
+        schema:
+          type: string
+          example: "The PubTrends Datasets Service is running"
+    """
+    return "The PubTrends Datasets Service is running", 200
+
 
 @app.route('/pubmed-to-gse', methods=['POST'])
 def get_pubmed_to_gse():


### PR DESCRIPTION
This PR introduces a health check endpoint at the `/` route and changes the port the app runs on to 5003 in README.md.

Fixes #34 