### PR TITLE
Fix key error in `/relevant_datasets` route

### DIFF
--- a/src/db/repositories/gsm_repository.py
+++ b/src/db/repositories/gsm_repository.py
@@ -78,7 +78,7 @@ class GSMRepository(GSMLoader):
                 gsms = {gsm.gsm: gsm for gsm in session.scalars(statement_gsms).all()}
 
                 for gse_acc in gse_gsm_map:
-                    gse_gsm_map[gse_acc] = [gsms[gsm_acc] for gsm_acc in gse_gsm_map[gse_acc]]
+                    gse_gsm_map[gse_acc] = [gsms[gsm_acc] for gsm_acc in gse_gsm_map[gse_acc] if gsm_acc in gsms]
 
                 return gse_gsm_map
 


### PR DESCRIPTION
This PR patches the `GSMRepository.get_gse_gsm_mapping` method to prevent `KeyError` exceptions from occuring when calling the `/relevant_datasets` endpoint.

Fixes #36 