### PR TITLE
Make GSE and GSM accession numbers non-nullable

### DIFF
--- a/scripts/make_gse_gsm_columns_not_null.sql
+++ b/scripts/make_gse_gsm_columns_not_null.sql
@@ -1,0 +1,76 @@
+PRAGMA foreign_keys=off;
+PRAGMA defer_foreign_keys=on;
+
+BEGIN;
+
+ALTER TABLE gse RENAME TO gse_old;
+CREATE TABLE gse (
+	"ID" REAL,
+	title TEXT,
+	gse TEXT NOT NULL,
+	status TEXT,
+	submission_date TEXT,
+	last_update_date TEXT,
+	pubmed_id INTEGER,
+	summary TEXT,
+	type TEXT,
+	contributor TEXT,
+	web_link TEXT,
+	overall_design TEXT,
+	repeats TEXT,
+	repeats_sample_list TEXT,
+	variable TEXT,
+	variable_description TEXT,
+	contact TEXT,
+	supplementary_file TEXT
+);
+
+INSERT INTO gse SELECT * FROM gse_old;
+
+DROP TABLE gse_old;
+
+CREATE UNIQUE INDEX idx_gse ON gse (gse);
+
+ALTER TABLE gsm RENAME TO gsm_old;
+CREATE TABLE gsm (
+	"ID" REAL,
+	"title" TEXT,
+	"gsm" TEXT NOT NULL,
+	"series_id" TEXT,
+	"gpl" TEXT,
+	"status" TEXT,
+	"submission_date" TEXT,
+	"last_update_date" TEXT,
+	"type" TEXT,
+	"source_name_ch1" TEXT,
+	"organism_ch1" TEXT,
+	"characteristics_ch1" TEXT,
+	"molecule_ch1" TEXT,
+	"label_ch1" TEXT,
+	"treatment_protocol_ch1" TEXT,
+	"extract_protocol_ch1" TEXT,
+	"label_protocol_ch1" TEXT,
+	"source_name_ch2" TEXT,
+	"organism_ch2" TEXT,
+	"characteristics_ch2" TEXT,
+	"molecule_ch2" TEXT,
+	"label_ch2" TEXT,
+	"treatment_protocol_ch2" TEXT,
+	"extract_protocol_ch2" TEXT,
+	"label_protocol_ch2" TEXT,
+	"hyb_protocol" TEXT,
+	"description" TEXT,
+	"data_processing" TEXT,
+	"contact" TEXT,
+	"supplementary_file" TEXT,
+	"data_row_count" REAL,
+	"channel_count" REAL
+);
+
+INSERT INTO gsm SELECT * FROM gsm_old;
+
+DROP TABLE gsm_old;
+
+CREATE UNIQUE INDEX idx_gsm ON gsm(gsm);
+
+COMMIT;

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -39,6 +39,9 @@ fi
 echo 'Adding foreign key constraint to geometadb'
 sqlite3 "${geometadb_path}" < scripts/gse_gsm_foreign_key_geometadb.sql
 
+echo 'Making gse and gsm columns non-nullable'
+sqlite3 "${geometadb_path}" < scripts/make_gse_gsm_columns_not_null.sql
+
 sed -i "s|^geometadb_path\\s*=\\s*.*|geometadb_path = ${geometadb_path}|" config.properties
 
 echo '4. Creating ~/.pubtrends-datasets directory'

--- a/src/db/models/gse.py
+++ b/src/db/models/gse.py
@@ -27,9 +27,9 @@ class GSE:
     )
     __sa_dataclass_metadata_key__ = "sa"
 
+    gse: str = field(metadata={"sa": Column(Text, primary_key=True)})
     ID: Optional[float] = field(default=None, metadata={"sa": Column(REAL)})
     title: Optional[str] = field(default=None, metadata={"sa": Column(Text)})
-    gse: Optional[str] = field(default=None, metadata={"sa": Column(Text, primary_key=True)})
     status: Optional[str] = field(default=None, metadata={"sa": Column(Text)})
     submission_date: Optional[str] = field(default=None, metadata={"sa": Column(Text)})
     last_update_date: Optional[str] = field(default=None, metadata={"sa": Column(Text)})

--- a/src/db/models/gsm.py
+++ b/src/db/models/gsm.py
@@ -18,9 +18,9 @@ class GSM:
     )
     __sa_dataclass_metadata_key__ = "sa"
 
+    gsm: str = field(metadata={"sa": Column(Text, primary_key=True)})
     ID: Optional[float] = field(default=None, metadata={"sa": Column(REAL)})
     title: Optional[str] = field(default=None, metadata={"sa": Column(Text)})
-    gsm: Optional[str] = field(default=None, metadata={"sa": Column(Text, primary_key=True)})
     series_id: Optional[str] = field(default=None, metadata={"sa": Column(Text)})
     gpl: Optional[str] = field(default=None, metadata={"sa": Column(Text)})
     status: Optional[str] = field(default=None, metadata={"sa": Column(Text)})


### PR DESCRIPTION
This PR changes the adds add a database migration and updates the data model in the flask app to make GSE and GSM accession number non-nullable.

To apply the new database migration rerun `setup.sh` or just run the `make_gse_gsm_columns_not_null.sql` script if the previous migrations are already applied.