### PR TITLE
Update README.md to include sqlite >= 3.50 in requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Datasets integration for PubTrends
 
 - Python 3
 - uv
+- sqlite >= 3.50
 
 ### General Setup
 


### PR DESCRIPTION
`scripts/create_test_sample.sh` depends on the unistr function, which was introduced in SQLite version 3.50. 

This PR adds an SQLite requirement to the "Prerequisites" section of the README to reflect this dependency.