### PR TITLE
Datasets Search via the ESearch API

### DIFF
--- a/src/app/app.py
+++ b/src/app/app.py
@@ -24,6 +24,8 @@ from src.db.models.gse import GSE_DTO, GSE
 from src.db.models.gsm import GSM
 from src.db.repositories.gse_repository import GSERepository
 from src.db.repositories.gsm_repository import GSMRepository
+from src.search.datasets_esearch import DatasetsSearch
+from src.search.models import PaginatedDatasets
 from src.semantic_search.embeddings_service import EmbeddingsServiceError
 from src.semantic_search.semantic_search import SemanticSearcher
 
@@ -637,6 +639,68 @@ def get_relevant_datasets_by_embedding():
         return jsonify({"error": str(e)}), 503
     except Exception as e:
         logger.exception(f'/relevant-datasets-by-embedding exception {e}')
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route('/search-datasets', methods=['GET'])
+def search_datasets():
+    """
+    GET endpoint to search for GEO datasets via ESearch.
+    ---
+    summary: Search for GEO datasets
+    description: Retrieves a paginated list of GSE accession numbers based on a search query.
+    parameters:
+      - name: query
+        in: query
+        type: string
+        required: true
+        description: The search query
+      - name: page
+        in: query
+        type: integer
+        required: false
+        default: 1
+        description: The page number (starting from 1)
+      - name: page_size
+        in: query
+        type: integer
+        required: false
+        default: 20
+        maximum: 1000
+        description: The number of items per page
+    responses:
+      200:
+        description: Successful response with total count and a list of GSE accessions
+        schema:
+          $ref: '#/definitions/PaginatedDatasets'
+      400:
+        description: Bad request - missing or invalid parameters
+        schema:
+          type: object
+          properties:
+            error:
+              type: string
+    """
+    logger.info(f'/search-datasets {log_request(request)}')
+    query = request.args.get('query')
+    if not query:
+        return jsonify({"error": "query parameter is required"}), 400
+
+    try:
+        page = request.args.get('page', default=1, type=int)
+        page_size = request.args.get('page_size', default=20, type=int)
+
+        if page < 1:
+            return jsonify({"error": "page parameter must be at least 1"}), 400
+        if page_size < 1:
+            return jsonify({"error": "page_size parameter must be at least 1"}), 400
+
+        with requests.Session() as http_session:
+            searcher = DatasetsSearch(http_session)
+            result = searcher.search(query, page=page, page_size=page_size)
+            return jsonify(asdict(result))
+    except Exception as e:
+        logger.exception(f'/search-datasets exception {e}')
         return jsonify({"error": str(e)}), 500
 
 

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -1,5 +1,6 @@
 """Flask application for GEOmetadb dataset queries."""
 import json
+import datetime
 from dataclasses import asdict
 
 import numpy as np
@@ -24,7 +25,7 @@ from src.db.models.gse import GSE_DTO, GSE
 from src.db.models.gsm import GSM
 from src.db.repositories.gse_repository import GSERepository
 from src.db.repositories.gsm_repository import GSMRepository
-from src.search.datasets_esearch import DatasetsSearch
+from src.search.datasets_esearch import DatasetsSearch, DatasetSearchFilters
 from src.search.models import PaginatedDatasets
 from src.semantic_search.embeddings_service import EmbeddingsServiceError
 from src.semantic_search.semantic_search import SemanticSearcher
@@ -668,6 +669,38 @@ def search_datasets():
         default: 20
         maximum: 1000
         description: The number of items per page
+      - name: from_pub_date
+        in: query
+        type: string
+        format: date
+        required: false
+        description: Filter datasets published after this date (YYYY-MM-DD)
+      - name: to_pub_date
+        in: query
+        type: string
+        format: date
+        required: false
+        description: Filter datasets published before this date (YYYY-MM-DD)
+      - name: from_update_date
+        in: query
+        type: string
+        format: date
+        required: false
+        description: Filter datasets updated after this date (YYYY-MM-DD)
+      - name: to_update_date
+        in: query
+        type: string
+        format: date
+        required: false
+        description: Filter datasets updated before this date (YYYY-MM-DD)
+      - name: experiment_types
+        in: query
+        type: array
+        items:
+          type: string
+        collectionFormat: multi
+        required: false
+        description: Filter by experiment types
     responses:
       200:
         description: Successful response with total count and a list of GSE accessions
@@ -695,10 +728,41 @@ def search_datasets():
         if page_size < 1:
             return jsonify({"error": "page_size parameter must be at least 1"}), 400
 
+        from_pub_date_str = request.args.get('from_pub_date')
+        to_pub_date_str = request.args.get('to_pub_date')
+        from_update_date_str = request.args.get('from_update_date')
+        to_update_date_str = request.args.get('to_update_date')
+        experiment_types = request.args.getlist('experiment_types')
+
+        def parse_date(date_str):
+            if not date_str:
+                return None
+            try:
+                return datetime.datetime.strptime(date_str, '%Y-%m-%d').date()
+            except ValueError:
+                raise ValueError(f"Invalid date format for '{date_str}', expected YYYY-MM-DD")
+
+        filter_args = {}
+        if from_pub_date_str:
+            filter_args['from_pub_date'] = parse_date(from_pub_date_str)
+        if to_pub_date_str:
+            filter_args['to_pub_date'] = parse_date(to_pub_date_str)
+        if from_update_date_str:
+            filter_args['from_update_date'] = parse_date(from_update_date_str)
+        if to_update_date_str:
+            filter_args['to_update_date'] = parse_date(to_update_date_str)
+        if experiment_types:
+            filter_args['experiment_types'] = experiment_types
+
+        filters = DatasetSearchFilters(**filter_args)
+        page_size = min(page_size, 1000)
+
         with requests.Session() as http_session:
             searcher = DatasetsSearch(http_session)
-            result = searcher.search(query, page=page, page_size=page_size)
+            result = searcher.search(query, filters=filters, page=page, page_size=page_size)
             return jsonify(asdict(result))
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
     except Exception as e:
         logger.exception(f'/search-datasets exception {e}')
         return jsonify({"error": str(e)}), 500

--- a/src/app/swagger_template.py
+++ b/src/app/swagger_template.py
@@ -111,6 +111,24 @@ swagger_template = {
                 }
             },
             "required": ["gse", "score"]
+        },
+        "PaginatedDatasets": {
+            "type": "object",
+            "properties": {
+                "total": {
+                    "type": "integer",
+                    "description": "The total number of datasets matching the query",
+                    "example": 123
+                },
+                "gse_accessions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "The list of GSE accession numbers for the requested page",
+                    "example": ["GSE116672", "GSE127884"]
+                }
+            }
         }
     }
 }

--- a/src/app/swagger_template.py
+++ b/src/app/swagger_template.py
@@ -118,7 +118,7 @@ swagger_template = {
                 "total": {
                     "type": "integer",
                     "description": "The total number of datasets matching the query",
-                    "example": 123
+                    "example": 100
                 },
                 "gse_accessions": {
                     "type": "array",
@@ -127,6 +127,16 @@ swagger_template = {
                     },
                     "description": "The list of GSE accession numbers for the requested page",
                     "example": ["GSE116672", "GSE127884"]
+                },
+                "page": {
+                    "type": "integer",
+                    "description": "The current page of results",
+                    "example": 1
+                },
+                "total_pages": {
+                    "type": "integer",
+                    "description": "The total number of pages of results",
+                    "example": 10
                 }
             }
         }

--- a/src/db/utils/get_geo_accessions_for_dates.py
+++ b/src/db/utils/get_geo_accessions_for_dates.py
@@ -1,51 +1,9 @@
-import re
-import time
-import xml.etree.ElementTree as ET
 import datetime
 from typing import List
-from urllib.request import urlopen, URLError
+import requests
 
-ESEARCH_BASE_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
-
-
-def url_open(url, timeout=5, n_trials=5, sleep_time=2):
-    """
-    Try open given url during specified timeout
-    :param url: url string
-    :param timeout: in seconds (e.g., 5 = 5 seconds)
-    :param n_trials: number of trials
-    :param sleep_time: in seconds (e.g., 2 = 2 seconds to sleep)
-    :return: http.client.HTTPResponse object in case of success
-    """
-    latest_exception = None
-    for trial in range(0, n_trials):
-        try:
-            response = urlopen(url, timeout=timeout)
-            return response
-        except (URLError, TimeoutError) as e:
-            latest_exception = e
-            time.sleep(sleep_time)
-    raise latest_exception
-
-
-def _get_geo_ids_batch(start_date: datetime.date, end_date: datetime.date) -> List[str]:
-    """
-    Find GSE which were last updated during given period, but up to 50000 GSEs per request.
-    :param start_date: date from which you want to search gse ids (e.g., "2019/12/02")
-    :param end_date: date until you want to search gse ids (e.g., "2019/12/05")
-    :return: GSE ids corresponding to request
-    """
-    start_date_str = start_date.strftime("%Y/%m/%d")
-    end_date_str = end_date.strftime("%Y/%m/%d")
-    xml_url = f"{ESEARCH_BASE_URL}?db=gds&term={start_date_str}:{end_date_str}[UDAT" \
-              f"]+AND+(gse[ETYP]+OR+gds[ETYP])&retmax=50000&usehistory=y "
-    gds_ids = url_open(xml_url).read()
-    gds_tree = ET.fromstring(gds_ids)
-    gds_pattern = re.compile(r'^20+')
-    gse_ids = list()
-    for elem in gds_tree.findall('IdList/Id'):
-        gse_ids.append(gds_pattern.sub('GSE', elem.text))
-    return gse_ids
+from src.search import DatasetsSearch
+from src.search.datasets_esearch import DatasetSearchFilters
 
 
 def get_gse_ids_by_last_update_date(start_date: datetime.date, end_date: datetime.date) -> List[str]:
@@ -55,18 +13,21 @@ def get_gse_ids_by_last_update_date(start_date: datetime.date, end_date: datetim
     :param end_date: date until you want to search gse ids (e.g., "2019/12/05")
     :return: GSE ids corresponding to request
     """
-    gse_ids = []
-    date_batches = []
-    batch_interval = datetime.timedelta(days=90)
-    while start_date <= end_date:
-        date_batches.append((start_date, min(start_date + batch_interval, end_date)))
-        start_date += batch_interval
-    for start_date, end_date in date_batches:
-        gse_ids.extend(_get_geo_ids_batch(start_date, end_date))
-    return list(set(gse_ids))
+    with requests.Session() as session:
+        searcher = DatasetsSearch(session)
+        gse_ids = []
+        filters = DatasetSearchFilters(from_update_date=start_date, to_update_date=end_date)
+        page_size = 50000
+
+        search_result = searcher.search("", filters, page_size=page_size, page=1)
+        while search_result.page <= search_result.total_pages:
+            gse_ids.extend([gse_accession for gse_accession in search_result.gse_accessions])
+            search_result = searcher.search("", filters, page_size=page_size, page=search_result.page + 1)
+
+        return gse_ids
 
 
 if __name__ == "__main__":
-    ids = _get_geo_ids_batch(datetime.date(2025, 10, 1), datetime.date(2025, 10, 3))
+    ids = get_gse_ids_by_last_update_date(datetime.date(2025, 10, 1), datetime.date(2025, 10, 3))
     for geo_id in ids:
         print(f"ftp://ftp.ncbi.nlm.nih.gov/geo/series/{geo_id[:-3]}nnn/{geo_id}/soft/{geo_id}_family.soft.gz")

--- a/src/search/__init__.py
+++ b/src/search/__init__.py
@@ -1,0 +1,4 @@
+from src.search.datasets_esearch import DatasetsSearch
+from src.search.models import PaginatedDatasets
+
+__all__ = ["DatasetsSearch", "PaginatedDatasets"]

--- a/src/search/datasets_esearch.py
+++ b/src/search/datasets_esearch.py
@@ -12,10 +12,14 @@ GSE_FILTER = "gse[ETYP]"
 
 logger = logging.getLogger(__name__)
 
+
 class DatasetSearchFilters:
     """Class for constructing search queries with filters."""
-    def __init__(self, from_pub_date: datetime.date = datetime.date(2000, 1, 1), to_pub_date: Optional[datetime.date] = None,
-                 experiment_types=None, from_update_date: datetime.date = datetime.date(2000, 1, 1), to_update_date: Optional[datetime.date] = None):
+
+    def __init__(self, from_pub_date: datetime.date = datetime.date(2000, 1, 1),
+                 to_pub_date: Optional[datetime.date] = None,
+                 experiment_types: list[str] | None = None, from_update_date: datetime.date = datetime.date(2000, 1, 1),
+                 to_update_date: Optional[datetime.date] = None):
         if experiment_types is None:
             experiment_types = []
         self.from_pub_date = from_pub_date
@@ -28,7 +32,8 @@ class DatasetSearchFilters:
         filter_term = f"({self.from_pub_date.strftime('%Y/%m/%d')}:{self.to_pub_date.strftime('%Y/%m/%d')}[PDAT])"
         filter_term += f" AND ({self.from_update_date.strftime('%Y/%m/%d')}:{self.to_update_date.strftime('%Y/%m/%d')}[UDAT])"
         if self.experiment_types:
-            processed_experiment_types = [f'"{experiment_type}"[DataSet Type]' for experiment_type in self.experiment_types]
+            processed_experiment_types = [f'"{experiment_type}"[DataSet Type]' for experiment_type in
+                                          self.experiment_types]
             filter_term += f" AND ({' OR '.join(processed_experiment_types)})"
         return filter_term
 
@@ -40,7 +45,8 @@ class DatasetsSearch:
         self.session = session
 
     @retry(wait=wait_exponential(multiplier=1, min=1, max=10), stop=stop_after_attempt(3), reraise=True)
-    def search(self, query: str, filters: DatasetSearchFilters, page: int = 1, page_size: int = 20) -> PaginatedDatasets:
+    def search(self, query: str, filters: DatasetSearchFilters, page: int = 1,
+               page_size: int = 20) -> PaginatedDatasets:
         """
         Search for datasets via ESearch with pagination.
 

--- a/src/search/datasets_esearch.py
+++ b/src/search/datasets_esearch.py
@@ -1,9 +1,35 @@
+import datetime
+import logging
+from typing import Optional
+
 import requests
-from tenacity import retry, wait_exponential
+from tenacity import retry, wait_exponential, stop_after_attempt
 
 from src.search.models import PaginatedDatasets
 
-GSE_FILTER = " AND gse[ETYP]"
+GSE_FILTER = "gse[ETYP]"
+
+logger = logging.getLogger(__name__)
+
+class DatasetSearchFilters:
+    """Class for constructing search queries with filters."""
+    def __init__(self, from_pub_date: datetime.date = datetime.date(2000, 1, 1), to_pub_date: Optional[datetime.date] = None,
+                 experiment_types=None, from_update_date: datetime.date = datetime.date(2000, 1, 1), to_update_date: Optional[datetime.date] = None):
+        if experiment_types is None:
+            experiment_types = []
+        self.from_pub_date = from_pub_date
+        self.to_pub_date = to_pub_date or datetime.date.today()
+        self.from_update_date = from_update_date
+        self.to_update_date = to_update_date or datetime.date.today()
+        self.experiment_types = experiment_types
+
+    def get_filter_term(self) -> str:
+        filter_term = f"({self.from_pub_date.strftime('%Y/%m/%d')}:{self.to_pub_date.strftime('%Y/%m/%d')}[PDAT])"
+        filter_term += f" AND ({self.from_update_date.strftime('%Y/%m/%d')}:{self.to_update_date.strftime('%Y/%m/%d')}[UDAT])"
+        if self.experiment_types:
+            processed_experiment_types = [f'"{experiment_type}"[DataSet Type]' for experiment_type in self.experiment_types]
+            filter_term += f" AND ({' OR '.join(processed_experiment_types)})"
+        return filter_term
 
 
 class DatasetsSearch:
@@ -12,13 +38,15 @@ class DatasetsSearch:
     def __init__(self, session: requests.Session):
         self.session = session
 
-    @retry(wait=wait_exponential(multiplier=1, min=4, max=10))
-    def search(self, query: str, page: int = 1, page_size: int = 20) -> PaginatedDatasets:
+    @retry(wait=wait_exponential(multiplier=1, min=1, max=10), stop=stop_after_attempt(3), reraise=True)
+    def search(self, query: str, filters: DatasetSearchFilters, page: int = 1, page_size: int = 20) -> PaginatedDatasets:
         """
         Search for datasets via ESearch with pagination.
 
         :param query: The search query.
         :type query: str
+        :param filters: The search filters.
+        :type filters: DatasetSearchFilters
         :param page: The page number (starting from 1), defaults to 1.
         :type page: int, optional
         :param page_size: The number of items per page, defaults to 20.
@@ -26,14 +54,17 @@ class DatasetsSearch:
         :return: Paginated search results containing total count and list of dataset IDs.
         :rtype: PaginatedDatasets
         """
+        # Default to today; computed here rather than in the signature to avoid
+        # being frozen to the date the function was first defined.
         base_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
-        page_size = min(page_size, 1000)
         retstart = (page - 1) * page_size
+        term = f"{query} AND {filters.get_filter_term()} AND {GSE_FILTER}"
+        logger.info("Calling ESearch with query: %s", term)
         response = self.session.get(
             f"{base_url}",
             params={
                 "db": "gds",
-                "term": query + GSE_FILTER,
+                "term": term,
                 "retmode": "json",
                 "retstart": retstart,
                 "retmax": page_size

--- a/src/search/datasets_esearch.py
+++ b/src/search/datasets_esearch.py
@@ -1,41 +1,14 @@
-import datetime
 import logging
 import math
-from typing import Optional
 
 import requests
 from tenacity import retry, wait_exponential, stop_after_attempt
 
-from src.search.models import PaginatedDatasets
+from src.search.models import PaginatedDatasets, DatasetSearchFilters
 
 GSE_FILTER = "gse[ETYP]"
 
 logger = logging.getLogger(__name__)
-
-
-class DatasetSearchFilters:
-    """Class for constructing search queries with filters."""
-
-    def __init__(self, from_pub_date: datetime.date = datetime.date(2000, 1, 1),
-                 to_pub_date: Optional[datetime.date] = None,
-                 experiment_types: list[str] | None = None, from_update_date: datetime.date = datetime.date(2000, 1, 1),
-                 to_update_date: Optional[datetime.date] = None):
-        if experiment_types is None:
-            experiment_types = []
-        self.from_pub_date = from_pub_date
-        self.to_pub_date = to_pub_date or datetime.date.today()
-        self.from_update_date = from_update_date
-        self.to_update_date = to_update_date or datetime.date.today()
-        self.experiment_types = experiment_types
-
-    def get_filter_term(self) -> str:
-        filter_term = f"({self.from_pub_date.strftime('%Y/%m/%d')}:{self.to_pub_date.strftime('%Y/%m/%d')}[PDAT])"
-        filter_term += f" AND ({self.from_update_date.strftime('%Y/%m/%d')}:{self.to_update_date.strftime('%Y/%m/%d')}[UDAT])"
-        if self.experiment_types:
-            processed_experiment_types = [f'"{experiment_type}"[DataSet Type]' for experiment_type in
-                                          self.experiment_types]
-            filter_term += f" AND ({' OR '.join(processed_experiment_types)})"
-        return filter_term
 
 
 class DatasetsSearch:

--- a/src/search/datasets_esearch.py
+++ b/src/search/datasets_esearch.py
@@ -1,0 +1,49 @@
+import requests
+from tenacity import retry, wait_exponential
+
+from src.search.models import PaginatedDatasets
+
+GSE_FILTER = " AND gse[ETYP]"
+
+
+class DatasetsSearch:
+    """Class for searching for datasets via ESearch."""
+
+    def __init__(self, session: requests.Session):
+        self.session = session
+
+    @retry(wait=wait_exponential(multiplier=1, min=4, max=10))
+    def search(self, query: str, page: int = 1, page_size: int = 20) -> PaginatedDatasets:
+        """
+        Search for datasets via ESearch with pagination.
+
+        :param query: The search query.
+        :type query: str
+        :param page: The page number (starting from 1), defaults to 1.
+        :type page: int, optional
+        :param page_size: The number of items per page, defaults to 20.
+        :type page_size: int, optional
+        :return: Paginated search results containing total count and list of dataset IDs.
+        :rtype: PaginatedDatasets
+        """
+        base_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+        page_size = min(page_size, 1000)
+        retstart = (page - 1) * page_size
+        response = self.session.get(
+            f"{base_url}",
+            params={
+                "db": "gds",
+                "term": query + GSE_FILTER,
+                "retmode": "json",
+                "retstart": retstart,
+                "retmax": page_size
+            }
+        )
+        response.raise_for_status()
+        data = response.json()["esearchresult"]
+        count = int(data.get("count", 0))
+        uids = data.get("idlist", [])
+        gse_uid_base = 200000000
+        gsm_uid_base = 300000000
+        items = ["GSE" + str(int(uid) - gse_uid_base) for uid in uids if gse_uid_base < int(uid) < gsm_uid_base]
+        return PaginatedDatasets(total=count, gse_accessions=items)

--- a/src/search/datasets_esearch.py
+++ b/src/search/datasets_esearch.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import math
 from typing import Optional
 
 import requests
@@ -58,7 +59,8 @@ class DatasetsSearch:
         # being frozen to the date the function was first defined.
         base_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
         retstart = (page - 1) * page_size
-        term = f"{query} AND {filters.get_filter_term()} AND {GSE_FILTER}"
+        query = query.strip()
+        term = f"{query} {'AND' if query else ''} {filters.get_filter_term()} AND {GSE_FILTER}"
         logger.info("Calling ESearch with query: %s", term)
         response = self.session.get(
             f"{base_url}",
@@ -77,4 +79,4 @@ class DatasetsSearch:
         gse_uid_base = 200000000
         gsm_uid_base = 300000000
         items = ["GSE" + str(int(uid) - gse_uid_base) for uid in uids if gse_uid_base < int(uid) < gsm_uid_base]
-        return PaginatedDatasets(total=count, gse_accessions=items)
+        return PaginatedDatasets(total=count, gse_accessions=items, page=page, total_pages=math.ceil(count / page_size))

--- a/src/search/models.py
+++ b/src/search/models.py
@@ -6,3 +6,5 @@ class PaginatedDatasets:
     """Class representing paginated search results for datasets."""
     total: int
     gse_accessions: list[str]
+    page: int
+    total_pages: int

--- a/src/search/models.py
+++ b/src/search/models.py
@@ -1,4 +1,31 @@
+import datetime
 from dataclasses import dataclass
+from typing import Optional
+
+
+class DatasetSearchFilters:
+    """Class for constructing search queries with filters."""
+
+    def __init__(self, from_pub_date: datetime.date = datetime.date(2000, 1, 1),
+                 to_pub_date: Optional[datetime.date] = None,
+                 experiment_types: list[str] | None = None, from_update_date: datetime.date = datetime.date(2000, 1, 1),
+                 to_update_date: Optional[datetime.date] = None):
+        if experiment_types is None:
+            experiment_types = []
+        self.from_pub_date = from_pub_date
+        self.to_pub_date = to_pub_date or datetime.date.today()
+        self.from_update_date = from_update_date
+        self.to_update_date = to_update_date or datetime.date.today()
+        self.experiment_types = experiment_types
+
+    def get_filter_term(self) -> str:
+        filter_term = f"({self.from_pub_date.strftime('%Y/%m/%d')}:{self.to_pub_date.strftime('%Y/%m/%d')}[PDAT])"
+        filter_term += f" AND ({self.from_update_date.strftime('%Y/%m/%d')}:{self.to_update_date.strftime('%Y/%m/%d')}[UDAT])"
+        if self.experiment_types:
+            processed_experiment_types = [f'"{experiment_type}"[DataSet Type]' for experiment_type in
+                                          self.experiment_types]
+            filter_term += f" AND ({' OR '.join(processed_experiment_types)})"
+        return filter_term
 
 
 @dataclass

--- a/src/search/models.py
+++ b/src/search/models.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class PaginatedDatasets:
+    """Class representing paginated search results for datasets."""
+    total: int
+    gse_accessions: list[str]

--- a/src/test/search/test_datasets_esearch.py
+++ b/src/test/search/test_datasets_esearch.py
@@ -1,0 +1,86 @@
+import unittest
+from unittest.mock import Mock
+import requests
+from src.search.datasets_esearch import DatasetsSearch, GSE_FILTER
+from src.search.models import PaginatedDatasets
+from src.test.helpers.http import create_mock_response
+
+
+class TestDatasetsSearch(unittest.TestCase):
+    def setUp(self):
+        self.mock_session = Mock(spec=requests.Session)
+        self.searcher = DatasetsSearch(self.mock_session)
+
+    def test_search_success(self):
+        mock_data = {
+            "esearchresult": {
+                "count": "2",
+                "idlist": ["200116672", "200127884"]
+            }
+        }
+        self.mock_session.get.return_value = create_mock_response(mock_data, 200)
+
+        result = self.searcher.search("test query")
+
+        self.assertEqual(result, PaginatedDatasets(total=2, gse_accessions=["GSE116672", "GSE127884"]))
+        self.mock_session.get.assert_called_once_with(
+            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+            params={
+                "db": "gds",
+                "term": "test query" + GSE_FILTER,
+                "retmode": "json",
+                "retstart": 0,
+                "retmax": 20
+            }
+        )
+
+    def test_search_pagination(self):
+        mock_data = {
+            "esearchresult": {
+                "count": "100",
+                "idlist": ["200000001"]
+            }
+        }
+        self.mock_session.get.return_value = create_mock_response(mock_data, 200)
+
+        result = self.searcher.search("test query", page=2, page_size=10)
+
+        self.assertEqual(result, PaginatedDatasets(total=100, gse_accessions=["GSE1"]))
+        self.mock_session.get.assert_called_once_with(
+            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+            params={
+                "db": "gds",
+                "term": "test query" + GSE_FILTER,
+                "retmode": "json",
+                "retstart": 10,
+                "retmax": 10
+            }
+        )
+
+    def test_search_max_page_size(self):
+        mock_data = {
+            "esearchresult": {
+                "count": "100",
+                "idlist": []
+            }
+        }
+        self.mock_session.get.return_value = create_mock_response(mock_data, 200)
+
+        self.searcher.search("test query", page_size=2000)
+
+        self.mock_session.get.assert_called_once_with(
+            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+            params={
+                "db": "gds",
+                "term": "test query" + GSE_FILTER,
+                "retmode": "json",
+                "retstart": 0,
+                "retmax": 1000
+            }
+        )
+
+    def test_search_error(self):
+        self.mock_session.get.return_value = create_mock_response("Error", 500)
+
+        with self.assertRaises(requests.HTTPError):
+            self.searcher.search("test query")

--- a/src/test/search/test_datasets_esearch.py
+++ b/src/test/search/test_datasets_esearch.py
@@ -24,7 +24,7 @@ class TestDatasetsSearch(unittest.TestCase):
         filter = DatasetSearchFilters()
         result = self.searcher.search("test query", filter)
 
-        self.assertEqual(result, PaginatedDatasets(total=2, gse_accessions=["GSE116672", "GSE127884"]))
+        self.assertEqual(result, PaginatedDatasets(total=2, gse_accessions=["GSE116672", "GSE127884"], page=1, total_pages=1))
         self.mock_session.get.assert_called_once_with(
             "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
             params={
@@ -48,7 +48,7 @@ class TestDatasetsSearch(unittest.TestCase):
         filter = DatasetSearchFilters()
         result = self.searcher.search("test query", filters=filter, page=2, page_size=10)
 
-        self.assertEqual(result, PaginatedDatasets(total=100, gse_accessions=["GSE1"]))
+        self.assertEqual(result, PaginatedDatasets(total=100, gse_accessions=["GSE1"], page=2, total_pages=10))
         self.mock_session.get.assert_called_once_with(
             "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
             params={

--- a/src/test/search/test_datasets_esearch.py
+++ b/src/test/search/test_datasets_esearch.py
@@ -1,7 +1,8 @@
+import datetime
 import unittest
 from unittest.mock import Mock
 import requests
-from src.search.datasets_esearch import DatasetsSearch, GSE_FILTER
+from src.search.datasets_esearch import DatasetsSearch, GSE_FILTER, DatasetSearchFilters
 from src.search.models import PaginatedDatasets
 from src.test.helpers.http import create_mock_response
 
@@ -20,14 +21,15 @@ class TestDatasetsSearch(unittest.TestCase):
         }
         self.mock_session.get.return_value = create_mock_response(mock_data, 200)
 
-        result = self.searcher.search("test query")
+        filter = DatasetSearchFilters()
+        result = self.searcher.search("test query", filter)
 
         self.assertEqual(result, PaginatedDatasets(total=2, gse_accessions=["GSE116672", "GSE127884"]))
         self.mock_session.get.assert_called_once_with(
             "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
             params={
                 "db": "gds",
-                "term": "test query" + GSE_FILTER,
+                "term": f"test query AND {filter.get_filter_term()} AND {GSE_FILTER}",
                 "retmode": "json",
                 "retstart": 0,
                 "retmax": 20
@@ -43,39 +45,18 @@ class TestDatasetsSearch(unittest.TestCase):
         }
         self.mock_session.get.return_value = create_mock_response(mock_data, 200)
 
-        result = self.searcher.search("test query", page=2, page_size=10)
+        filter = DatasetSearchFilters()
+        result = self.searcher.search("test query", filters=filter, page=2, page_size=10)
 
         self.assertEqual(result, PaginatedDatasets(total=100, gse_accessions=["GSE1"]))
         self.mock_session.get.assert_called_once_with(
             "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
             params={
                 "db": "gds",
-                "term": "test query" + GSE_FILTER,
+                "term": f"test query AND {filter.get_filter_term()} AND {GSE_FILTER}",
                 "retmode": "json",
                 "retstart": 10,
                 "retmax": 10
-            }
-        )
-
-    def test_search_max_page_size(self):
-        mock_data = {
-            "esearchresult": {
-                "count": "100",
-                "idlist": []
-            }
-        }
-        self.mock_session.get.return_value = create_mock_response(mock_data, 200)
-
-        self.searcher.search("test query", page_size=2000)
-
-        self.mock_session.get.assert_called_once_with(
-            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
-            params={
-                "db": "gds",
-                "term": "test query" + GSE_FILTER,
-                "retmode": "json",
-                "retstart": 0,
-                "retmax": 1000
             }
         )
 
@@ -83,4 +64,16 @@ class TestDatasetsSearch(unittest.TestCase):
         self.mock_session.get.return_value = create_mock_response("Error", 500)
 
         with self.assertRaises(requests.HTTPError):
-            self.searcher.search("test query")
+            self.searcher.search("test query", filters=DatasetSearchFilters())
+
+
+    def test_filter_term(self):
+        filter = DatasetSearchFilters(
+            from_pub_date=datetime.date(2022, 1, 1),
+            to_pub_date=datetime.date(2022, 12, 31),
+            from_update_date=datetime.date(2023, 1, 1),
+            to_update_date=datetime.date(2023, 12, 31),
+            experiment_types=["type 1", "type 2"]
+        )
+
+        self.assertEqual(filter.get_filter_term(), '(2022/01/01:2022/12/31[PDAT]) AND (2023/01/01:2023/12/31[UDAT]) AND ("type 1"[DataSet Type] OR "type 2"[DataSet Type])')


### PR DESCRIPTION
This PR introduces the `/search_datasets` endpoint, which enables users to perform keyword searches for datasets. The endpoint uses ESearch as its backend. Additionally, `/search_datasets` supports filtering by experiment type, publication and update date.

Fetching datasets updated in a given time period in `src/db/utils/get_geo_accessions_for_dates.py` is now done using the `DatasetsSearch` class implemented this PR to eliminate duplicated logic. 